### PR TITLE
Fix documents directory lookup

### DIFF
--- a/x-health/RecordController.swift
+++ b/x-health/RecordController.swift
@@ -19,26 +19,28 @@ class RecordController: ObservableObject {
     
     // MARK: - Image Saving Helpers
     
-    /// Returns the app’s Documents directory.
-    func getDocumentsDirectory() -> URL {
-        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    /// Returns the app's Documents directory if available.
+    func getDocumentsDirectory() -> URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
     }
     
     /// Saves a UIImage as a JPEG to the Documents directory and returns the filename.
     func saveImage(_ image: UIImage) -> String? {
-        if let data = image.jpegData(compressionQuality: 0.8) {
-            let fileName = UUID().uuidString + ".jpg"
-            let url = getDocumentsDirectory().appendingPathComponent(fileName)
-            do {
-                try data.write(to: url)
-                print("Saved image at \(url)")
-                return fileName
-            } catch {
-                print("Error saving image: \(error)")
-                return nil
-            }
+        guard let data = image.jpegData(compressionQuality: 0.8),
+              let documentsURL = getDocumentsDirectory() else {
+            return nil
         }
-        return nil
+
+        let fileName = UUID().uuidString + ".jpg"
+        let url = documentsURL.appendingPathComponent(fileName)
+        do {
+            try data.write(to: url)
+            print("Saved image at \(url)")
+            return fileName
+        } catch {
+            print("Error saving image: \(error)")
+            return nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- improve `RecordController` file writing reliability by checking for a documents directory before saving

## Testing
- `swiftc -parse x-health/RecordController.swift`

------
https://chatgpt.com/codex/tasks/task_e_6864b7ad9ae4832fb7cbadb26bcef449