### PR TITLE
Fix CI by sharing Xcode scheme

### DIFF
--- a/x-health.xcodeproj/xcshareddata/xcschemes/x-health.xcscheme
+++ b/x-health.xcodeproj/xcshareddata/xcschemes/x-health.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion="1600"
+   version="1.7">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="6E1072E72D4F568100DFCD2E"
+               BuildableName="x-health.app"
+               BlueprintName="x-health"
+               ReferencedContainer="container:x-health.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction buildConfiguration="Debug" codeCoverageEnabled="NO" runDestinationActionMask="0" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+      <TestPlans>
+      </TestPlans>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="6E1072E72D4F568100DFCD2E"
+            BuildableName="x-health.app"
+            BlueprintName="x-health"
+            ReferencedContainer="container:x-health.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" debugServiceExtension="internal" allowLocationSimulation="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="6E1072E72D4F568100DFCD2E"
+            BuildableName="x-health.app"
+            BlueprintName="x-health"
+            ReferencedContainer="container:x-health.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
+      <BuildableProductRunnable runnableDebuggingMode="0">
+         <BuildableReference
+            BuildableIdentifier="primary"
+            BlueprintIdentifier="6E1072E72D4F568100DFCD2E"
+            BuildableName="x-health.app"
+            BlueprintName="x-health"
+            ReferencedContainer="container:x-health.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration="Debug"/>
+   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES"/>
+</Scheme>


### PR DESCRIPTION
## Summary
- share the default Xcode scheme so CI can build

## Testing
- `swift --version`
- `swift package describe` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6864b7ddfe98832f97f60a04114c7337