### PR TITLE
Add vector app icon

### DIFF
--- a/x-health/Assets.xcassets/AppIcon.appiconset/AppIcon.svg
+++ b/x-health/Assets.xcassets/AppIcon.appiconset/AppIcon.svg
@@ -1,0 +1,4 @@
+<svg width="1024" height="1024" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1024" height="1024" fill="#1DB954"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" fill="#FFFFFF" font-family="Helvetica, Arial, sans-serif" font-size="200">x-health</text>
+</svg>

--- a/x-health/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/x-health/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,35 +1,17 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "platform" : "ios",
-      "size" : "1024x1024"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "idiom" : "universal",
-      "platform" : "ios",
-      "size" : "1024x1024"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "tinted"
-        }
-      ],
-      "idiom" : "universal",
-      "platform" : "ios",
+      "idiom" : "ios-marketing",
+      "filename" : "AppIcon.svg",
+      "scale" : "1x",
       "size" : "1024x1024"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
## Summary
- replace binary PNG app icon with SVG vector
- update asset metadata to use vector icon

## Testing
- `git ls-tree -r HEAD x-health/Assets.xcassets/AppIcon.appiconset`


------
https://chatgpt.com/codex/tasks/task_e_6864bc68ae38832f933de12c16b686c9