### PR TITLE
Add release distribution instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,3 +13,21 @@
 
 ## Known Issues
 - None reported
+
+## Distributing the App
+
+Follow these steps when you are ready to ship a build to TestFlight or the App Store:
+
+1. **Archive the app**
+   - Open `x-health.xcodeproj` in Xcode.
+   - Select the *Any iOS Device* destination and choose **Product > Archive**.
+2. **Upload via Xcode**
+   - In the Organizer window, choose **Distribute App** and select **App Store Connect**.
+   - Pick either **TestFlight** for beta testing or **App Store** for a production release.
+3. **Enter metadata** in App Store Connect
+   - Fill in version information, description, screenshots, and compliance details.
+   - Ensure the `Version` listed above matches the value you submit.
+4. **Submit for review**
+   - After validation, submit the build for TestFlight beta review or App Store review.
+
+These steps assume you have configured an App Store Connect account with the appropriate Bundle ID and provisioning profiles.


### PR DESCRIPTION
## Summary
- document steps for distributing the app via TestFlight or the App Store in `RELEASE.md`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6864c206e75c832f9a79ee39546a3f5a