### PR TITLE
Add basic unit tests

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -46,7 +46,7 @@ jobs:
           # The runners currently provide iPhone 16 simulators running iOS 18.2.
           xcodebuild -project x-health.xcodeproj -scheme x-health -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build
 
-      # Optionally, add test steps if you have unit/UI tests
-      # - name: Run tests
-      #   run: |
-      #     xcodebuild test -project x-health.xcodeproj -scheme x-health -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0'
+      # Run unit tests
+      - name: Run tests
+        run: |
+          xcodebuild test -project x-health.xcodeproj -scheme x-health -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2'

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "x-health",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(name: "x-health", targets: ["x-health"]),
+    ],
+    targets: [
+        .target(name: "x-health", path: "x-health"),
+        .testTarget(name: "x-healthTests", dependencies: ["x-health"], path: "x-healthTests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ x-health is an iOS application for managing and tracking health records, body pa
 - Main code is in `Views/` and root Swift files
 - Assets are in `Assets.xcassets`
 - CI/CD is set up with GitHub Actions (`.github/workflows/ios-build.yml`)
+- Basic unit tests are located in `x-healthTests/`. Run them with `xcodebuild test`.
 
 ## License
 MIT License

--- a/x-healthTests/ModelsTests.swift
+++ b/x-healthTests/ModelsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import x_health
+
+final class ModelsTests: XCTestCase {
+    func testDoctorEncodingDecoding() throws {
+        let doctor = Doctor(name: "Dr. Jane", lastVisit: Date())
+        let data = try JSONEncoder().encode(doctor)
+        let decoded = try JSONDecoder().decode(Doctor.self, from: data)
+        XCTAssertEqual(doctor, decoded)
+    }
+
+    func testTagEncodingDecoding() throws {
+        let tag = Tag(name: "Important", colorHex: "#FF0000")
+        let data = try JSONEncoder().encode(tag)
+        let decoded = try JSONDecoder().decode(Tag.self, from: data)
+        XCTAssertEqual(tag, decoded)
+    }
+}

--- a/x-healthTests/RecordControllerTests.swift
+++ b/x-healthTests/RecordControllerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import x_health
+
+final class RecordControllerTests: XCTestCase {
+    func testAddRecord() {
+        let controller = RecordController()
+        XCTAssertTrue(controller.records.isEmpty)
+
+        let doctor = Doctor(name: "Dr. Jones", lastVisit: Date())
+        let record = MedicalRecord(type: .doctorVisit,
+                                   date: Date(),
+                                   notes: "Checkup",
+                                   doctor: doctor)
+
+        controller.addRecord(record)
+
+        XCTAssertEqual(controller.records.count, 1)
+        XCTAssertTrue(controller.records.first === record)
+    }
+}

--- a/x-healthTests/UtilityTests.swift
+++ b/x-healthTests/UtilityTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import x_health
+
+final class UtilityTests: XCTestCase {
+    func testDateFormatterMediumStyle() {
+        XCTAssertEqual(dateFormatter.dateStyle, .medium)
+    }
+}


### PR DESCRIPTION
## Summary
- add Swift Package manifest for tests
- add basic tests for models and controller
- enable test step in CI workflow
- document how to run tests

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6864c2393230832fa6d3d04430c64224