### PR TITLE
Add TestFlight and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: App Store Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Import signing certificate
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.P12_BASE64 }}
+          p12-password: ${{ secrets.P12_PASSWORD }}
+
+      - name: Build archive
+        run: |
+          xcodebuild -project x-health.xcodeproj \
+            -scheme x-health \
+            -configuration Release \
+            -archivePath $PWD/build/x-health.xcarchive \
+            clean archive
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $PWD/build/x-health.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath $PWD/build
+
+      - name: Upload to App Store
+        uses: apple-actions/upload-app-store-build@v1
+        with:
+          app-path: build/x-health.ipa
+          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
+          api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,45 @@
+name: TestFlight
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+
+      - name: Import signing certificate
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.P12_BASE64 }}
+          p12-password: ${{ secrets.P12_PASSWORD }}
+
+      - name: Build archive
+        run: |
+          xcodebuild -project x-health.xcodeproj \
+            -scheme x-health \
+            -configuration Release \
+            -archivePath $PWD/build/x-health.xcarchive \
+            clean archive
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $PWD/build/x-health.xcarchive \
+            -exportOptionsPlist ExportOptions.plist \
+            -exportPath $PWD/build
+
+      - name: Upload to TestFlight
+        uses: apple-actions/upload-testflight-build@v1
+        with:
+          app-path: build/x-health.ipa
+          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
+          api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ x-health is an iOS application for managing and tracking health records, body pa
 - Main code is in `Views/` and root Swift files
 - Assets are in `Assets.xcassets`
 - CI/CD is set up with GitHub Actions (`.github/workflows/ios-build.yml`)
+- TestFlight workflow: `.github/workflows/testflight.yml`
+- App Store release workflow: `.github/workflows/release.yml`
 
 ## License
 MIT License


### PR DESCRIPTION
## Summary
- create TestFlight upload workflow
- create App Store release workflow
- add export options plist for releases
- document new workflows in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864c1d2adb4832f8127b54584b0ecdc