### PR TITLE
Add medication tracker with reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ x-health is an iOS application for managing and tracking health records, body pa
 - Compare records
 - Manage doctors and body parts
 - Image gallery and zoom
+- Track medicines with daily reminders
 
 ## Getting Started
 1. Clone the repository

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@ This file tracks upcoming improvements and provides an overview of the project s
 - [ ] Improve the user interface and overall user experience
 - [ ] Expand health record features (graphs, export options)
 - [ ] Prepare for App Store release
+- [ ] Add medication tracker with reminders
 
 ## File Hierarchy (partial)
 ```

--- a/x-health/Medication.swift
+++ b/x-health/Medication.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+import UserNotifications
+
+@Model
+final class Medication: Identifiable {
+    var id: UUID
+    var name: String
+    var dosage: String
+    var reminderTime: Date
+    var startDate: Date
+    var endDate: Date
+
+    init(name: String, dosage: String, reminderTime: Date, startDate: Date, endDate: Date) {
+        self.id = UUID()
+        self.name = name
+        self.dosage = dosage
+        self.reminderTime = reminderTime
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}
+
+extension Medication {
+    /// Schedule a daily notification reminder for this medication.
+    func scheduleReminder() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Take \(self.name)"
+            content.body = self.dosage
+            content.sound = .default
+
+            var components = Calendar.current.dateComponents([.hour, .minute], from: self.reminderTime)
+            components.calendar = Calendar.current
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+            let request = UNNotificationRequest(identifier: self.id.uuidString, content: content, trigger: trigger)
+            UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+        }
+    }
+
+    /// Cancel the scheduled reminder for this medication.
+    func cancelReminder() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [self.id.uuidString])
+    }
+}

--- a/x-health/Views/AddMedicationView.swift
+++ b/x-health/Views/AddMedicationView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import SwiftData
+
+struct AddMedicationView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @State private var dosage: String = ""
+    @State private var reminderTime = Date()
+    @State private var startDate = Date()
+    @State private var endDate = Date()
+
+    var body: some View {
+        Form {
+            Section(header: Text("Medicine Details")) {
+                TextField("Name", text: $name)
+                TextField("Dosage", text: $dosage)
+                DatePicker("Reminder Time", selection: $reminderTime, displayedComponents: .hourAndMinute)
+                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+                DatePicker("End Date", selection: $endDate, displayedComponents: .date)
+            }
+            Button("Save Medicine") {
+                let med = Medication(name: name, dosage: dosage, reminderTime: reminderTime, startDate: startDate, endDate: endDate)
+                modelContext.insert(med)
+                try? modelContext.save()
+                med.scheduleReminder()
+                dismiss()
+            }
+        }
+        .navigationTitle("Add Medicine")
+    }
+}

--- a/x-health/Views/HomeView.swift
+++ b/x-health/Views/HomeView.swift
@@ -30,6 +30,9 @@ struct HomeView: View {
                     NavigationLink(destination: AddTagView()) {
                         HomeButton(title: "Add Tag", subtitle: "New tag and color")
                     }
+                    NavigationLink(destination: MedicineTrackerView()) {
+                        HomeButton(title: "Medicines", subtitle: "Track and remind")
+                    }
                 }
                 .padding(.horizontal, 20)
                 Spacer()

--- a/x-health/Views/MedicineTrackerView.swift
+++ b/x-health/Views/MedicineTrackerView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import SwiftData
+import UserNotifications
+
+struct MedicineTrackerView: View {
+    @Query(sort: \Medication.startDate, order: .forward) var medications: [Medication]
+    @Environment(\.modelContext) private var modelContext
+    @State private var showAdd = false
+
+    var body: some View {
+        List {
+            ForEach(medications) { med in
+                VStack(alignment: .leading) {
+                    Text(med.name)
+                        .font(.headline)
+                    Text(med.dosage)
+                        .font(.subheadline)
+                    HStack {
+                        Text("Reminder: \(med.reminderTime, style: .time)")
+                        Spacer()
+                        Text("\(med.startDate, formatter: dateFormatter) - \(med.endDate, formatter: dateFormatter)")
+                            .font(.caption)
+                    }
+                }
+            }
+            .onDelete(perform: delete)
+        }
+        .navigationTitle("Medicines")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showAdd = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showAdd) {
+            NavigationView { AddMedicationView() }
+        }
+    }
+
+    func delete(at offsets: IndexSet) {
+        for index in offsets {
+            let med = medications[index]
+            med.cancelReminder()
+            modelContext.delete(med)
+        }
+        try? modelContext.save()
+    }
+}

--- a/x-health/x_healthApp.swift
+++ b/x-health/x_healthApp.swift
@@ -15,6 +15,6 @@ struct x_healthAppApp: App {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: [MedicalRecord.self, Doctor.self, Tag.self])
+        .modelContainer(for: [MedicalRecord.self, Doctor.self, Tag.self, Medication.self])
     }
 }

--- a/x-healthTests/ModelsTests.swift
+++ b/x-healthTests/ModelsTests.swift
@@ -15,4 +15,11 @@ final class ModelsTests: XCTestCase {
         let decoded = try JSONDecoder().decode(Tag.self, from: data)
         XCTAssertEqual(tag, decoded)
     }
+    func testMedicationEncodingDecoding() throws {
+        let med = Medication(name: "Aspirin", dosage: "1 pill", reminderTime: Date(), startDate: Date(), endDate: Date().addingTimeInterval(3600))
+        let data = try JSONEncoder().encode(med)
+        let decoded = try JSONDecoder().decode(Medication.self, from: data)
+        XCTAssertEqual(med.name, decoded.name)
+        XCTAssertEqual(med.dosage, decoded.dosage)
+    }
 }


### PR DESCRIPTION
## Summary
- add `Medication` model with reminder scheduling
- create `AddMedicationView` and `MedicineTrackerView`
- expose medicine tracker on the home screen
- update model container to include `Medication`
- document new feature in README and TODO
- test JSON encoding/decoding for `Medication`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687088ab11c0832fb44abf17722d048b