### PR TITLE
Improve medication tracking

### DIFF
--- a/x-health/Views/AddMedicationView.swift
+++ b/x-health/Views/AddMedicationView.swift
@@ -7,46 +7,83 @@ struct AddMedicationView: View {
 
     @State private var name: String = ""
     @State private var dosage: String = ""
-    @State private var doseTime = Date()
-    @State private var strength: String = ""
-    @State private var quantity: Int = 1
-    @State private var notes: String = ""
+    /// Temporary dose entries for the form. These are converted to `MedicationDose`
+    /// objects when the medicine is saved.
+    struct DoseEntry: Identifiable {
+        var id = UUID()
+        var time: Date
+        var strength: String
+        var quantity: Int
+        var notes: String
+    }
+
+    @State private var doses: [DoseEntry] = [DoseEntry(time: Date(), strength: "", quantity: 1, notes: "")]
+
     @State private var startDate = Date()
     @State private var endDate = Date()
     @State private var supplyCount: Int = 0
     @State private var refillThreshold: Int = 0
+    @State private var showError = false
+    @State private var errorMessage = ""
 
     var body: some View {
         Form {
             Section(header: Text("Medicine Details")) {
                 TextField("Name", text: $name)
                 TextField("Dosage", text: $dosage)
-                DatePicker("Dose Time", selection: $doseTime, displayedComponents: .hourAndMinute)
-                TextField("Strength", text: $strength)
-                Stepper(value: $quantity, in: 1...10) {
-                    Text("Quantity: \(quantity)")
+            }
+
+            Section(header: Text("Doses")) {
+                ForEach($doses) { $dose in
+                    VStack(alignment: .leading) {
+                        DatePicker("Dose Time", selection: $dose.time, displayedComponents: .hourAndMinute)
+                        TextField("Strength", text: $dose.strength)
+                        Stepper(value: $dose.quantity, in: 1...10) {
+                            Text("Quantity: \(dose.quantity)")
+                        }
+                        TextField("Notes", text: $dose.notes)
+                    }
                 }
-                TextField("Notes", text: $notes)
+                .onDelete { indexSet in
+                    doses.remove(atOffsets: indexSet)
+                }
+                Button(action: { doses.append(DoseEntry(time: Date(), strength: "", quantity: 1, notes: "")) }) {
+                    Label("Add Dose", systemImage: "plus")
+                }
+            }
+
+            Section {
                 DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
                 DatePicker("End Date", selection: $endDate, displayedComponents: .date)
                 Stepper(value: $supplyCount, in: 0...1000) { Text("Supply: \(supplyCount)") }
                 Stepper(value: $refillThreshold, in: 0...1000) { Text("Refill Alert at: \(refillThreshold)") }
             }
+
             Button("Save Medicine") {
-                let dose = MedicationDose(time: doseTime, strength: strength, quantity: quantity, notes: notes)
-                let med = Medication(name: name,
-                                     dosage: dosage,
-                                     doses: [dose],
-                                     startDate: startDate,
-                                     endDate: endDate,
-                                     supplyCount: supplyCount,
-                                     refillThreshold: refillThreshold)
-                modelContext.insert(med)
-                try? modelContext.save()
-                med.scheduleReminders()
-                dismiss()
+                do {
+                    let medDoses = doses.map { MedicationDose(time: $0.time, strength: $0.strength, quantity: $0.quantity, notes: $0.notes) }
+                    let med = Medication(name: name,
+                                         dosage: dosage,
+                                         doses: medDoses,
+                                         startDate: startDate,
+                                         endDate: endDate,
+                                         supplyCount: supplyCount,
+                                         refillThreshold: refillThreshold)
+                    modelContext.insert(med)
+                    try modelContext.save()
+                    med.scheduleReminders()
+                    dismiss()
+                } catch {
+                    errorMessage = error.localizedDescription
+                    showError = true
+                }
             }
         }
         .navigationTitle("Add Medicine")
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage)
+        }
     }
 }

--- a/x-health/Views/MedicineTrackerView.swift
+++ b/x-health/Views/MedicineTrackerView.swift
@@ -6,6 +6,7 @@ struct MedicineTrackerView: View {
     @Query(sort: \Medication.startDate, order: .forward) var medications: [Medication]
     @Environment(\.modelContext) private var modelContext
     @State private var showAdd = false
+    @State private var errorMessage: String? = nil
 
     var body: some View {
         List {
@@ -15,11 +16,13 @@ struct MedicineTrackerView: View {
                         .font(.headline)
                     Text(med.dosage)
                         .font(.subheadline)
-                    if let firstDose = med.doses.first {
+                    if let nextDose = med.doses.first(where: { $0.status != .taken }) {
                         HStack {
-                            Text("Next: \(firstDose.time, style: .time)")
+                            Text("Next: \(nextDose.time, style: .time)")
                             Spacer()
-                            Text("Supply: \(med.supplyCount)")
+                            Button(action: { markTaken(med: med, dose: nextDose) }) {
+                                Image(systemName: nextDose.status == .taken ? "checkmark.circle.fill" : "circle")
+                            }
                         }
                     }
                     Text("\(med.startDate, formatter: dateFormatter) - \(med.endDate, formatter: dateFormatter)")
@@ -39,6 +42,11 @@ struct MedicineTrackerView: View {
         .sheet(isPresented: $showAdd) {
             NavigationView { AddMedicationView() }
         }
+        .alert("Error", isPresented: .constant(errorMessage != nil), actions: {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        }, message: {
+            Text(errorMessage ?? "")
+        })
     }
 
     func delete(at offsets: IndexSet) {
@@ -47,6 +55,19 @@ struct MedicineTrackerView: View {
             med.cancelReminders()
             modelContext.delete(med)
         }
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func markTaken(med: Medication, dose: MedicationDose) {
+        med.mark(dose: dose, status: .taken)
+        do {
+            try modelContext.save()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }

--- a/x-healthTests/ModelsTests.swift
+++ b/x-healthTests/ModelsTests.swift
@@ -24,4 +24,12 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(med.dosage, decoded.dosage)
         XCTAssertEqual(decoded.doses.count, 1)
     }
+
+    func testMarkDoseTakenUpdatesSupply() throws {
+        let dose = MedicationDose(time: Date(), strength: "500mg", quantity: 1)
+        let med = Medication(name: "Ibuprofen", dosage: "tablet", doses: [dose], startDate: Date(), endDate: Date().addingTimeInterval(3600), supplyCount: 5, refillThreshold: 1)
+        med.mark(dose: dose, status: .taken)
+        XCTAssertEqual(med.doses.first?.status, .taken)
+        XCTAssertEqual(med.supplyCount, 4)
+    }
 }


### PR DESCRIPTION
## Summary
- allow creating multiple doses for a medication and show an error dialog on failure
- show upcoming dose in the medicine list with ability to mark it as taken
- unit test dose taken logic

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6870965b168c832f89c118a4bb4c6adb