### PR TITLE
Fix daily medicine checklist reset

### DIFF
--- a/x-health/Medication.swift
+++ b/x-health/Medication.swift
@@ -12,6 +12,8 @@ final class Medication: Identifiable {
     var endDate: Date
     var supplyCount: Int
     var refillThreshold: Int
+    /// The last date the daily checklist was reset. Stored at midnight UTC.
+    var lastReset: Date
 
     init(name: String,
          dosage: String,
@@ -19,7 +21,8 @@ final class Medication: Identifiable {
          startDate: Date,
          endDate: Date,
          supplyCount: Int = 0,
-         refillThreshold: Int = 0) {
+         refillThreshold: Int = 0,
+         lastReset: Date = Calendar.current.startOfDay(for: Date())) {
         self.id = UUID()
         self.name = name
         self.dosage = dosage
@@ -28,6 +31,7 @@ final class Medication: Identifiable {
         self.endDate = endDate
         self.supplyCount = supplyCount
         self.refillThreshold = refillThreshold
+        self.lastReset = lastReset
     }
 }
 
@@ -77,5 +81,15 @@ extension Medication {
         content.sound = .default
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
         UNUserNotificationCenter.current().add(UNNotificationRequest(identifier: "refill-\(id.uuidString)", content: content, trigger: trigger), withCompletionHandler: nil)
+    }
+
+    /// Reset all dose statuses at the start of a new day.
+    func resetForNewDay() {
+        let today = Calendar.current.startOfDay(for: Date())
+        guard !Calendar.current.isDate(lastReset, inSameDayAs: today) else { return }
+        for index in doses.indices {
+            doses[index].status = .pending
+        }
+        lastReset = today
     }
 }

--- a/x-health/Views/MedicineTrackerView.swift
+++ b/x-health/Views/MedicineTrackerView.swift
@@ -28,46 +28,51 @@ struct MedicineTrackerView: View {
     }
 
     var body: some View {
-        List {
-            if !todayDoses.isEmpty {
-                Section(header: Text("Today Log")) {
-                    ForEach(todayDoses, id: \.1.id) { pair in
-                        let med = pair.0
-                        let dose = pair.1
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text(med.name).font(.headline)
-                                Text(dose.strength).font(.caption)
-                            }
-                            Spacer()
-                            Text(dose.time, style: .time)
-                            Button(action: { markTaken(med: med, dose: dose) }) {
-                                Image(systemName: dose.status == .taken ? "checkmark.circle.fill" : "circle")
-                            }
-                        }
-                    }
-                }
-            }
-
-            Section(header: Text("Medicines")) {
-                ForEach(medications) { med in
-                    VStack(alignment: .leading) {
-                        Text(med.name)
-                            .font(.headline)
-                        Text(med.dosage)
-                            .font(.subheadline)
-                        if let nextDose = med.doses.first(where: { $0.status != .taken }) {
+        VStack {
+            Text(Date(), formatter: dateFormatter)
+                .font(.headline)
+                .padding(.top, 8)
+            List {
+                if !todayDoses.isEmpty {
+                    Section(header: Text("Today Log")) {
+                        ForEach(todayDoses, id: \.1.id) { pair in
+                            let med = pair.0
+                            let dose = pair.1
                             HStack {
-                                Text("Next: \(nextDose.time, style: .time)")
+                                VStack(alignment: .leading) {
+                                    Text(med.name).font(.headline)
+                                    Text(dose.strength).font(.caption)
+                                }
                                 Spacer()
+                                Text(dose.time, style: .time)
+                                Button(action: { markTaken(med: med, dose: dose) }) {
+                                    Image(systemName: dose.status == .taken ? "checkmark.circle.fill" : "circle")
+                                }
                             }
                         }
-                        Text("\(med.startDate, formatter: dateFormatter) - \(med.endDate, formatter: dateFormatter)")
-                            .font(.caption)
                     }
-                    .onTapGesture { selectedMedication = med }
                 }
-                .onDelete(perform: delete)
+
+                Section(header: Text("Medicines")) {
+                    ForEach(medications) { med in
+                        VStack(alignment: .leading) {
+                            Text(med.name)
+                                .font(.headline)
+                            Text(med.dosage)
+                                .font(.subheadline)
+                            if let nextDose = med.doses.first(where: { $0.status != .taken }) {
+                                HStack {
+                                    Text("Next: \(nextDose.time, style: .time)")
+                                    Spacer()
+                                }
+                            }
+                            Text("\(med.startDate, formatter: dateFormatter) - \(med.endDate, formatter: dateFormatter)")
+                                .font(.caption)
+                        }
+                        .onTapGesture { selectedMedication = med }
+                    }
+                    .onDelete(perform: delete)
+                }
             }
         }
         .navigationTitle("Medicines")
@@ -95,6 +100,9 @@ struct MedicineTrackerView: View {
         }, message: {
             Text(errorMessage ?? "")
         })
+        .onAppear {
+            resetDaily()
+        }
     }
 
     func delete(at offsets: IndexSet) {
@@ -112,6 +120,17 @@ struct MedicineTrackerView: View {
 
     private func markTaken(med: Medication, dose: MedicationDose) {
         med.mark(dose: dose, status: .taken)
+        do {
+            try modelContext.save()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func resetDaily() {
+        for med in medications {
+            med.resetForNewDay()
+        }
         do {
             try modelContext.save()
         } catch {

--- a/x-healthTests/ModelsTests.swift
+++ b/x-healthTests/ModelsTests.swift
@@ -32,4 +32,12 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(med.doses.first?.status, .taken)
         XCTAssertEqual(med.supplyCount, 4)
     }
+
+    func testResetForNewDaySetsPending() {
+        let dose = MedicationDose(time: Date(), strength: "5mg", quantity: 1, status: .taken)
+        let med = Medication(name: "Test", dosage: "pill", doses: [dose], startDate: Date(), endDate: Date())
+        med.lastReset = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        med.resetForNewDay()
+        XCTAssertEqual(med.doses.first?.status, .pending)
+    }
 }


### PR DESCRIPTION
## Summary
- reset medicine doses every day using a new `lastReset` field
- show the current date and reset meds on opening the tracker view
- add unit test for daily reset

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687462a4ead0832fbf793829e522f6a4